### PR TITLE
Don't pass context to loading template

### DIFF
--- a/src/django_ajax/templatetags/xhr.py
+++ b/src/django_ajax/templatetags/xhr.py
@@ -30,7 +30,7 @@ class XhrNode(Node):
                 return container % self.else_nodelist.render(context)
             else:
                 template = getattr(settings, 'XHR_LOADING_TEMPLATE', 'django-ajax/_loader.html')
-                return container % loader.get_template(template).render(context)
+                return container % loader.get_template(template).render()
 
 
 @register.tag


### PR DESCRIPTION
Django 1.11 doesn't support this anymore, but since it's the loading
template anyway, it doesn't need the context.