### PR TITLE
Improve XSS protection

### DIFF
--- a/django_ajax/static/ajax-utilities/js/pagination.js
+++ b/django_ajax/static/ajax-utilities/js/pagination.js
@@ -52,8 +52,9 @@ var Pagination = new function() {
 
             function ajax(url, handler) {
                 // URL should start with a slash, but cannot start with two slashes.
+		// we cannot start with "/\". Modern browsers handle backslashes as normal slashes.
                 // (Otherwise we have an XSS vulnerability.)
-                if (url[0] != '/' || url[1] == '/')
+                if (url[0] != '/' || url[1] == '/' || url.startsWith("/\\")
                     url = (''+location).replace( /[#\?].*/, '') + url;
 
                 // Append 'xhr' to make sure all content is loaded.


### PR DESCRIPTION
Modern browsers treat the backslash as normal slashes when used in the URLs. So instead of using the hash value "#page://google.com", we can use "#page:/\google.com" to bypasses the XSS protection